### PR TITLE
fix: fix preflight css

### DIFF
--- a/.changeset/rude-jokes-worry.md
+++ b/.changeset/rude-jokes-worry.md
@@ -1,5 +1,0 @@
----
-"@hiogawa/unocss-preset-antd": patch
----
-
-fix preflight reset css

--- a/.changeset/rude-jokes-worry.md
+++ b/.changeset/rude-jokes-worry.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/unocss-preset-antd": patch
+---
+
+fix preflight reset css

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hiogawa/unocss-preset-antd-app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [9ab7eb6]
+  - @hiogawa/unocss-preset-antd@2.0.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,6 +7,7 @@
     "build": "run-s build:*",
     "build:vite": "vite build",
     "build:vercel": "bash misc/vercel/build.sh",
+    "preview": "vite preview",
     "generate-tw": "unocss-typescript-dsl --outDir src/styles/tw",
     "release": "vercel deploy --prebuilt .",
     "release-production": "vercel deploy --prebuilt . --prod"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-preset-antd-app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "dev": "vite --no-clearScreen",

--- a/packages/app/src/styles/index.ts
+++ b/packages/app/src/styles/index.ts
@@ -1,2 +1,3 @@
 import "virtual:uno.css";
+import "@hiogawa/unocss-preset-antd/dist/reset";
 import "./index.css";

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hiogawa/unocss-preset-antd
 
+## 2.0.1
+
+### Patch Changes
+
+- 9ab7eb6: fix preflight reset css
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-preset-antd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,6 +10,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/reset": {
+      "import": "./dist/reset.js",
+      "require": "./dist/reset.cjs",
+      "types": "./dist/reset.d.ts"
     }
   },
   "files": [

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,15 +1,10 @@
-import fs from "node:fs";
-import { booleanGuard, tinyassert } from "@hiogawa/utils";
 import type { Theme } from "@unocss/preset-uno";
-import { resolveModule } from "local-pkg";
 import { pickBy } from "lodash";
 import type { Preset } from "unocss";
 import { theme } from "./theme";
 import { tw } from "./tw";
 
-export function antdPreset(
-  options: { noPreflight?: boolean } = {}
-): Preset<Theme> {
+export function antdPreset(): Preset<Theme> {
   return {
     name: "antd-preset",
     prefix: "antd-",
@@ -112,14 +107,6 @@ export function antdPreset(
         .hover(tw.text_colorPrimaryHover.border_colorPrimaryHover)
         .aria_selected(tw.text_colorPrimary.border_colorPrimary).$,
     },
-    preflights: [
-      !options.noPreflight && {
-        getCSS: async () => {
-          const reset = await readUnocssReset(); // borrow default preset of unocss
-          return reset + "\n\n\n" + PREFLIGHT;
-        },
-      },
-    ].filter(booleanGuard),
   };
 }
 
@@ -135,32 +122,3 @@ function toCssVariables(
     Object.entries(tokens).map(([k, v]) => ["--antd-" + k, String(v)])
   );
 }
-
-async function readUnocssReset() {
-  const cssPath = resolveModule("@unocss/reset/tailwind.css");
-  tinyassert(cssPath);
-  const content = await fs.promises.readFile(cssPath, "utf-8");
-  return content;
-}
-
-const PREFLIGHT = `\
-:root {
-  color-scheme: light;
-  --at-apply: "antd-variables-default";
-}
-
-.dark {
-  color-scheme: dark;
-  --at-apply: "antd-variables-dark";
-}
-
-body {
-  --at-apply: "antd-body";
-}
-
-*,
-::before,
-::after {
-  --at-apply: "antd-reset";
-}
-`;

--- a/packages/lib/src/reset.css
+++ b/packages/lib/src/reset.css
@@ -1,0 +1,19 @@
+:root {
+  color-scheme: light;
+  --at-apply: "antd-variables-default";
+}
+
+.dark {
+  color-scheme: dark;
+  --at-apply: "antd-variables-dark";
+}
+
+body {
+  --at-apply: "antd-body";
+}
+
+*,
+::before,
+::after {
+  --at-apply: "antd-reset";
+}

--- a/packages/lib/src/reset.ts
+++ b/packages/lib/src/reset.ts
@@ -1,0 +1,3 @@
+// isort-ignore
+import "@unocss/reset/tailwind.css";
+import "./reset.css";

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/reset.ts"],
+  entry: ["src/index.ts", "src/reset.ts", "src/reset.css"],
   format: ["esm", "cjs"],
   external: ["./reset.css"],
-  dts: true,
+  dts: {
+    entry: ["src/index.ts", "src/reset.ts"],
+  },
   splitting: false,
 });

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/reset.ts"],
   format: ["esm", "cjs"],
+  external: ["./reset.css"],
   dts: true,
+  splitting: false,
 });


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/unocss-preset-antd/pull/20

Clearly not working:

```css
{color-scheme:light;--at-apply: "antd-variables-default"}.dark{color-scheme:dark;--at-apply: "antd-variables-dark"}body{--at-apply: "antd-body"}*,:before,:after{--at-apply: "antd-reset"}
```

Emitted css's `--at-apply` is not resolved...

<details>

![image](https://user-images.githubusercontent.com/4232207/222952445-50ef5c92-f48b-4aa7-94f8-1a9434b22fa4.png)

</details>