### PR TITLE
feat: pass `FloatingContext` in `PopoverSimple`

### DIFF
--- a/packages/app/src/components/popover.tsx
+++ b/packages/app/src/components/popover.tsx
@@ -91,6 +91,10 @@ export function Popover(props: {
   );
 }
 
+//
+// simple wrapper with transition
+//
+
 // https://ant.design/components/popover
 export function PopoverSimple({
   placement,
@@ -98,14 +102,16 @@ export function PopoverSimple({
   floating,
 }: {
   placement: Placement;
-  reference: React.ReactElement;
-  floating: React.ReactElement;
+  reference: MaybeCallable<React.ReactElement, [FloatingContext]>;
+  floating: MaybeCallable<React.ReactElement, [FloatingContext]>;
 }) {
   return (
     <Popover
       placement={placement}
-      reference={({ props }) => React.cloneElement(reference, props)}
-      floating={({ props, open, arrowProps, context: { placement } }) => (
+      reference={({ props, context }) =>
+        React.cloneElement(maybeCall(reference, [context]), props)
+      }
+      floating={({ props, open, arrowProps, context: c }) => (
         <Transition
           show={open}
           className="transition duration-150"
@@ -120,20 +126,20 @@ export function PopoverSimple({
             <div
               {...arrowProps}
               className={cls(
-                placement.startsWith("bottom") && "top-0",
-                placement.startsWith("top") && "bottom-0",
-                placement.startsWith("left") && "right-0",
-                placement.startsWith("right") && "left-0"
+                c.placement.startsWith("bottom") && "top-0",
+                c.placement.startsWith("top") && "bottom-0",
+                c.placement.startsWith("left") && "right-0",
+                c.placement.startsWith("right") && "left-0"
               )}
             >
               <div
                 // rotate 4x4 square with shadow
                 className={cls(
                   "bg-colorBgElevated shadow-[var(--antd-boxShadowPopoverArrow)] relative w-4 h-4",
-                  placement.startsWith("bottom") && "-top-2 rotate-[225deg]",
-                  placement.startsWith("top") && "-bottom-2 rotate-[45deg]",
-                  placement.startsWith("left") && "-right-2 rotate-[315deg]",
-                  placement.startsWith("right") && "-left-2 rotate-[135deg]"
+                  c.placement.startsWith("bottom") && "-top-2 rotate-[225deg]",
+                  c.placement.startsWith("top") && "-bottom-2 rotate-[45deg]",
+                  c.placement.startsWith("left") && "-right-2 rotate-[315deg]",
+                  c.placement.startsWith("right") && "-left-2 rotate-[135deg]"
                 )}
                 // clip half
                 style={{
@@ -141,10 +147,23 @@ export function PopoverSimple({
                 }}
               />
             </div>
-            {floating}
+            {maybeCall(floating, [c])}
           </div>
         </Transition>
       )}
     />
   );
+}
+
+//
+// misc
+//
+
+type MaybeCallable<T, Args extends any[]> = T | ((...args: Args) => T);
+
+function maybeCall<T, Args extends any[]>(
+  f: MaybeCallable<T, Args>,
+  args: Args
+): T {
+  return typeof f === "function" ? (f as any)(...args) : f;
 }

--- a/packages/app/src/components/stories.tsx
+++ b/packages/app/src/components/stories.tsx
@@ -3,6 +3,7 @@ import { range } from "@hiogawa/utils";
 import { Debug, toDelayedSetState } from "@hiogawa/utils-react";
 import React from "react";
 import { tw } from "../styles/tw";
+import { cls } from "../utils/misc";
 import { useCollapseProps } from "./collapse";
 import { useModal } from "./modal";
 import { PopoverSimple } from "./popover";
@@ -320,17 +321,29 @@ export function StoryPopover() {
                   <PopoverSimple
                     key={i}
                     placement={placement}
-                    reference={
-                      <button className="antd-btn antd-btn-default py-1 px-2">
+                    reference={(context) => (
+                      <button
+                        className={cls(
+                          "antd-btn antd-btn-default py-1 px-2",
+                          context.open &&
+                            tw.text_colorPrimaryActive.border_colorPrimaryActive
+                              .$
+                        )}
+                      >
                         {placement.replace("-", "\n")}
                       </button>
-                    }
-                    floating={
-                      <div className="flex flex-col gap-1 px-3 py-2 w-[150px]">
-                        <h4 className="text-lg">Title</h4>
+                    )}
+                    floating={(context) => (
+                      <div className="flex flex-col gap-2 px-3 py-2 w-[150px] text-sm">
                         <div>Content</div>
+                        <button
+                          className={tw.antd_btn.antd_btn_default.$}
+                          onClick={() => context.onOpenChange(false)}
+                        >
+                          Close
+                        </button>
                       </div>
-                    }
+                    )}
                   />
                 );
               }


### PR DESCRIPTION
This would allow accessing `open` (e.g. highlight active state) and `onOpenChange` (e.g. close button in floating) to be utilized from the caller side.
Such enhancement is realized in 
- https://github.com/hi-ogawa/ytsub-v3/pull/191

## screenshots

![image](https://user-images.githubusercontent.com/4232207/226158989-30802e46-102d-42f1-a3ab-472bb46d67ac.png)
