### PR TITLE
feat: disable button hover styling for touch device

### DIFF
--- a/.changeset/hot-papayas-approve.md
+++ b/.changeset/hot-papayas-approve.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/unocss-preset-antd": minor
+---
+
+feat: disable button hover styling on touch device

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-preset-antd",
-  "version": "2.2.0",
+  "version": "2.2.1-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-preset-antd",
-  "version": "2.2.1-pre.0",
+  "version": "2.2.1-pre.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -74,28 +74,34 @@ export function antdPreset(options?: { reset?: boolean }): Preset<Theme> {
       ).$,
 
       "btn-text": tw.not_disabled(
+        // "hover" state on touch device can be confusing as it sticks even after the touch release.
+        // This is critical, for example, when `antd-btn` is used as toggle.
+        // Thus, such style is enabled only on "mouse" device (i.e. `(hover) and (pointer: fine)`).
+        // Also, to get around with selector "specificity" issue, we need `:hover:not(:active)`.
         tw
-          .hover(tw.media_mouse(tw.bg_colorBgTextHover))
+          .hover(tw.not_active(tw.media_mouse(tw.bg_colorBgTextHover)))
           .active(tw.bg_colorBgTextActive)
       ).$,
 
       "btn-ghost": tw.not_disabled(
         tw
-          .hover(tw.media_mouse(tw.text_colorPrimaryHover))
+          .hover(tw.not_active(tw.media_mouse(tw.text_colorPrimaryHover)))
           .active(tw.text_colorPrimaryActive)
       ).$,
 
       "btn-default": tw.border.border_colorBorder.not_disabled(
         tw
           .hover(
-            tw.media_mouse(tw.text_colorPrimaryHover.border_colorPrimaryHover)
+            tw.not_active(
+              tw.media_mouse(tw.text_colorPrimaryHover.border_colorPrimaryHover)
+            )
           )
           .active(tw.text_colorPrimaryActive.border_colorPrimaryActive)
       ).$,
 
       "btn-primary": tw.text_white.bg_colorPrimary.not_disabled(
         tw
-          .hover(tw.media_mouse(tw.bg_colorPrimaryHover))
+          .hover(tw.not_active(tw.media_mouse(tw.bg_colorPrimaryHover)))
           .active(tw.bg_colorPrimaryActive)
       ).$,
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -73,6 +73,7 @@ export function antdPreset(options?: { reset?: boolean }): Preset<Theme> {
         tw.cursor_not_allowed.opacity_50
       ).$,
 
+      // TODO: `hover` on touch device can be confusing. consider restricting the variant by "media-mouse:hover:xxx".
       "btn-text": tw.not_disabled(
         tw.hover(tw.bg_colorBgTextHover).active(tw.bg_colorBgTextActive)
       ).$,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -73,23 +73,30 @@ export function antdPreset(options?: { reset?: boolean }): Preset<Theme> {
         tw.cursor_not_allowed.opacity_50
       ).$,
 
-      // TODO: `hover` on touch device can be confusing. consider restricting the variant by "media-mouse:hover:xxx".
       "btn-text": tw.not_disabled(
-        tw.hover(tw.bg_colorBgTextHover).active(tw.bg_colorBgTextActive)
+        tw
+          .hover(tw.media_mouse(tw.bg_colorBgTextHover))
+          .active(tw.bg_colorBgTextActive)
       ).$,
 
       "btn-ghost": tw.not_disabled(
-        tw.hover(tw.text_colorPrimaryHover).active(tw.text_colorPrimaryActive)
+        tw
+          .hover(tw.media_mouse(tw.text_colorPrimaryHover))
+          .active(tw.text_colorPrimaryActive)
       ).$,
 
       "btn-default": tw.border.border_colorBorder.not_disabled(
         tw
-          .hover(tw.text_colorPrimaryHover.border_colorPrimaryHover)
+          .hover(
+            tw.media_mouse(tw.text_colorPrimaryHover.border_colorPrimaryHover)
+          )
           .active(tw.text_colorPrimaryActive.border_colorPrimaryActive)
       ).$,
 
       "btn-primary": tw.text_white.bg_colorPrimary.not_disabled(
-        tw.hover(tw.bg_colorPrimaryHover).active(tw.bg_colorPrimaryActive)
+        tw
+          .hover(tw.media_mouse(tw.bg_colorPrimaryHover))
+          .active(tw.bg_colorPrimaryActive)
       ).$,
 
       /**

--- a/packages/lib/src/tw/types.ts
+++ b/packages/lib/src/tw/types.ts
@@ -1699,6 +1699,7 @@ export type Variant =
   | `hover`
   | `important`
   | `aria_${Theme_aria}`
+  | `media_${Theme_media}`
 ;
 
 export type Shortcut =

--- a/packages/lib/uno.config.ts
+++ b/packages/lib/uno.config.ts
@@ -1,6 +1,10 @@
 // used to generate tw-api.ts
 
-import { dummyRule, filterColorPallete } from "@hiogawa/unocss-typescript-dsl";
+import {
+  dummyRule,
+  dummyVariant,
+  filterColorPallete,
+} from "@hiogawa/unocss-typescript-dsl";
 import { dummyPreset } from "@hiogawa/unocss-typescript-dsl";
 import {
   defineConfig,
@@ -21,5 +25,6 @@ export default defineConfig({
     dummyRule("opacity-<percent>"),
     dummyRule("rounded-full"),
   ],
+  variants: [dummyVariant("media-$media")],
   transformers: [transformerDirectives(), transformerVariantGroup()],
 });


### PR DESCRIPTION
Without this there are some inconvenience when button is used as toggle e.g.
- https://github.com/hi-ogawa/ytsub-v3/pull/193

Maybe such behavior should be configurable via options.