### PR TITLE
chore(tiny-tansition): remove type peer dep

### DIFF
--- a/packages/tiny-transition/package.json
+++ b/packages/tiny-transition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-transition",
-  "version": "0.0.1-pre.2",
+  "version": "0.0.1-pre.3",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -39,14 +39,10 @@
     "react": "^18.2.0"
   },
   "peerDependencies": {
-    "@types/react": "^18.0.0",
     "react": "^18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
-      "optional": true
-    },
-    "@types/react": {
       "optional": true
     }
   }


### PR DESCRIPTION
Even if optional peer-dep, it doesn't seem this is normal thing react library does. So let's remove it.