### PR TITLE
chore(app): persist form state on url query

### DIFF
--- a/packages/app/src/components/stories.tsx
+++ b/packages/app/src/components/stories.tsx
@@ -14,6 +14,7 @@ import React from "react";
 import ReactSelect from "react-select";
 import { tw } from "../styles/tw";
 import { cls } from "../utils/misc";
+import { useUrlQuery } from "../utils/url-utils";
 import { getCollapseProps } from "./collapse";
 import { useModal } from "./modal";
 import { PopoverSimple } from "./popover";
@@ -774,16 +775,21 @@ export function StoryCubicBezier() {
   };
   type Preset = keyof typeof PRESETS;
 
+  const query = createTinyForm(
+    useUrlQuery({
+      input: "0.25, 0.1, 0.25, 1",
+    })
+  );
+
   const form = createTinyForm(
     React.useState({
-      input: "0.25, 0.1, 0.25, 1",
       preset: none<Preset>(),
       duration: "3s",
       play: false,
     })
   );
 
-  const numbers = form.data.input.split(",").map((v) => Number.parseFloat(v));
+  const numbers = query.data.input.split(",").map((v) => Number.parseFloat(v));
   const [x1, _y1, x2, _y2] = numbers;
   const isValid =
     numbers.length === 4 &&
@@ -810,7 +816,7 @@ export function StoryCubicBezier() {
                 labelFn={(v) => v ?? "- Preset -"}
                 onChange={(v) => {
                   if (v) {
-                    form.fields.input.onChange(PRESETS[v].join(", "));
+                    query.fields.input.onChange(PRESETS[v].join(", "));
                   }
                   form.fields.preset.onChange(v);
                 }}
@@ -819,7 +825,7 @@ export function StoryCubicBezier() {
             <input
               className="antd-input p-1"
               aria-invalid={!isValid}
-              {...form.fields.input.props()}
+              {...query.fields.input.props()}
             />
           </label>
           <div className="self-center w-full">
@@ -879,7 +885,7 @@ export function StoryCubicBezier() {
                     className="absolute inset-0 bg-colorSuccess"
                     style={{
                       transformOrigin: "0 0",
-                      transition: `transform ${form.data.duration} cubic-bezier(${form.data.input})`,
+                      transition: `transform ${form.data.duration} cubic-bezier(${query.data.input})`,
                     }}
                     enterFrom="scale-x-0"
                     enterTo="scale-x-100"

--- a/packages/app/src/utils/url-utils.ts
+++ b/packages/app/src/utils/url-utils.ts
@@ -1,0 +1,22 @@
+import { useSearchParams } from "react-router-dom";
+
+type NextState<T> = T | ((prev: T) => T);
+
+type SetState<T> = (next: NextState<T>) => void;
+
+function resolveNext<T>(prev: () => T, next: NextState<T>): T {
+  return typeof next === "function" ? (next as any)(() => prev) : prev;
+}
+
+// simple state helper for string-key-value on URLSearchParams
+export function useUrlQuery<T extends Record<string, string>>(defaultValue: T) {
+  const [params, setParams] = useSearchParams(defaultValue);
+
+  const state = Object.fromEntries(params.entries()) as T;
+
+  const setState: SetState<T> = (next) => {
+    setParams(new URLSearchParams(resolveNext(() => state, next)));
+  };
+
+  return [state, setState] as const;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "moduleResolution": "Node",
     "module": "ESNext",
     "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": []
   }
 }


### PR DESCRIPTION
A little experiment with `useUrlQuery`.
The similar one exists in https://github.com/hi-ogawa/ytsub-v3/blob/249c5caaab824c0b10fa83d1c46259aa6f127211/app/utils/loader-utils.ts#L29-L76
but I thought we could make simpler but convenient enough one here, which integrates better with `createTinyForm`.