### PR TITLE
refactor(tiny-transition): remove "base" class option

### DIFF
--- a/packages/app-solid/src/components/transition.tsx
+++ b/packages/app-solid/src/components/transition.tsx
@@ -5,11 +5,14 @@ import {
   TransitionManagerV2,
   convertClassPropsToCallbackProps,
 } from "@hiogawa/tiny-transition";
+import { once, tinyassert } from "@hiogawa/utils";
 import {
   type JSX,
   Show,
+  batch,
   createEffect,
   createMemo,
+  createRenderEffect,
   createSignal,
   onCleanup,
   untrack,
@@ -96,16 +99,21 @@ export function TransitionV2(
 
   return (
     <Show when={state()}>
-      <div
+      <EffectWrapper manager={manager} class={props.class} style={props.style}>
+        {props.children}
+      </EffectWrapper>
+      {/* <div
+        // use:refHack={1}
+        // use:refHack={2}
         ref={(el) => {
           // TODO: need to ensure class/style applied before manager.ref?
           // TODO: should move `manager.ref` to `createRenderEffect`?
-          if (props.class) {
-            solidClassName(el, props.class);
-          }
-          if (props.style) {
-            solidStyle(el, props.style as any);
-          }
+          // if (props.class) {
+          //   solidClassName(el, props.class);
+          // }
+          // if (props.style) {
+          //   solidStyle(el, props.style as any);
+          // }
           // untrack(() => {
           //   if (props.class) {
           //     solidClassName(el, props.class);
@@ -115,13 +123,65 @@ export function TransitionV2(
           //   }
           // });
           // console.log(el.className, el.style.cssText);
+          // batch(() => manager.ref(el));
+          // queueMicrotask(() => manager.ref(el));
+          console.log("== ref");
           manager.ref(el);
         }}
+        // class={() => {
+        //   return props.class;
+        // }}
         class={props.class}
         style={props.style}
+        prop:__refHack={(() => {
+          console.log("__refHack");
+          return 0;
+        })()}
       >
         {props.children}
-      </div>
+      </div> */}
     </Show>
+  );
+}
+
+// function refHack(el: Element, value: () => unknown) {
+//   console.log("== refHack", value());
+//   // const [field, setField] = value();
+//   // createRenderEffect(() => (el.value = field()));
+//   // el.addEventListener("input", (e) => setField(e.target.value));
+// }
+
+function EffectWrapper(
+  props: { manager: TransitionManagerV2 } & Pick<
+    JSX.HTMLElementTags["div"],
+    "class" | "children" | "style"
+  >
+) {
+  let ref!: HTMLElement;
+
+  // need to delay `manager.ref` call from solid-js's own `ref` phase to  `createRenderEffect`.
+  // this is because solid-js's `ref` runs before `class/style` props handling.
+  // createRenderEffect(() => {
+  //   tinyassert(ref);
+  //   props.manager.ref(ref);
+  // });
+
+  onCleanup(() => {
+    props.manager.ref(null);
+  });
+
+  return (
+    <div
+      ref={(el) => (ref = el)}
+      class={props.class}
+      style={props.style}
+      // @ts-ignore
+      prop:__TransitionManagerRefHack={once(() => {
+        tinyassert(ref);
+        props.manager.ref(ref);
+      })()}
+    >
+      {props.children}
+    </div>
   );
 }

--- a/packages/app-solid/src/components/transition.tsx
+++ b/packages/app-solid/src/components/transition.tsx
@@ -53,7 +53,11 @@ export function Transition(
 
   return (
     <Show when={shouldRender()}>
-      <div ref={(el) => manager.setElement(el)} style={props.style}>
+      <div
+        ref={(el) => manager.setElement(el)}
+        class={props.class}
+        style={props.style}
+      >
         {props.children}
       </div>
     </Show>
@@ -91,7 +95,11 @@ export function TransitionV2(
 
   return (
     <Show when={state()}>
-      <div ref={(el) => manager.ref(el)} style={props.style}>
+      <div
+        ref={(el) => manager.ref(el)}
+        class={props.class}
+        style={props.style}
+      >
         {props.children}
       </div>
     </Show>

--- a/packages/app-solid/src/components/transition.tsx
+++ b/packages/app-solid/src/components/transition.tsx
@@ -24,7 +24,7 @@ export function Transition(
     Pick<JSX.HTMLElementTags["div"], "class" | "children" | "style">
 ) {
   const callbackOptions = createMemo(() =>
-    convertClassPropsToCallbackProps(props.class, props)
+    convertClassPropsToCallbackProps(props)
   );
 
   const manager = new TransitionManager(
@@ -73,7 +73,7 @@ export function TransitionV2(
     () =>
       new TransitionManagerV2(
         props.appear ? false : props.show,
-        convertClassPropsToCallbackProps(props.class, props)
+        convertClassPropsToCallbackProps(props)
       )
   );
   const [state, setState] = createSignal(manager.state);

--- a/packages/app-solid/src/components/transition.tsx
+++ b/packages/app-solid/src/components/transition.tsx
@@ -14,6 +14,7 @@ import {
   onCleanup,
   untrack,
 } from "solid-js";
+import { className as solidClassName, style as solidStyle } from "solid-js/web";
 
 export function Transition(
   props: {
@@ -96,7 +97,26 @@ export function TransitionV2(
   return (
     <Show when={state()}>
       <div
-        ref={(el) => manager.ref(el)}
+        ref={(el) => {
+          // TODO: need to ensure class/style applied before manager.ref?
+          // TODO: should move `manager.ref` to `createRenderEffect`?
+          if (props.class) {
+            solidClassName(el, props.class);
+          }
+          if (props.style) {
+            solidStyle(el, props.style as any);
+          }
+          // untrack(() => {
+          //   if (props.class) {
+          //     solidClassName(el, props.class);
+          //   }
+          //   if (props.style) {
+          //     solidStyle(el, props.style as any);
+          //   }
+          // });
+          // console.log(el.className, el.style.cssText);
+          manager.ref(el);
+        }}
         class={props.class}
         style={props.style}
       >

--- a/packages/tiny-transition/src/class.ts
+++ b/packages/tiny-transition/src/class.ts
@@ -19,11 +19,9 @@ export type TransitionClassType = (typeof TRANSITION_CLASS_TYPES)[number];
 export type TransitionClassProps = Partial<Record<TransitionClassType, string>>;
 
 export function convertClassPropsToCallbackProps(
-  base: string | undefined,
   props: TransitionClassProps & TransitionCallbackProps
 ): TransitionCallbackProps {
   const cl = {
-    base: splitClass(base ?? ""),
     enter: splitClass(props.enter ?? ""),
     enterFrom: splitClass(props.enterFrom ?? ""),
     enterTo: splitClass(props.enterTo ?? ""),
@@ -38,32 +36,31 @@ export function convertClassPropsToCallbackProps(
   return {
     onEnterFrom: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base, ...cl.enterFrom, ...cl.enter);
+      el.classList.add(...cl.enterFrom, ...cl.enter);
       props.onEnterFrom?.(el);
     },
     onEnterTo: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base, ...cl.enterTo, ...cl.enter);
+      el.classList.add(...cl.enterTo, ...cl.enter);
       props.onEnterTo?.(el);
     },
     onEntered: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base, ...cl.enterTo, ...cl.entered);
+      el.classList.add(...cl.enterTo, ...cl.entered);
       props.onEntered?.(el);
     },
     onLeaveFrom: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base, ...cl.leaveFrom, ...cl.leave);
+      el.classList.add(...cl.leaveFrom, ...cl.leave);
       props.onLeaveFrom?.(el);
     },
     onLeaveTo: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base, ...cl.leaveTo, ...cl.leave);
+      el.classList.add(...cl.leaveTo, ...cl.leave);
       props.onLeaveTo?.(el);
     },
     onLeft: (el) => {
       el.classList.remove(...all);
-      el.classList.add(...cl.base);
       props.onLeft?.(el);
     }
   };

--- a/packages/tiny-transition/src/react-v2.tsx
+++ b/packages/tiny-transition/src/react-v2.tsx
@@ -54,7 +54,7 @@ export const TransitionV2 = simpleForawrdRef(function TransitionV2(
   // define stable callbacks with ref element
   const elRef = React.useRef<HTMLElement | null>(null);
   const callbacks = objectMapValues(
-    convertClassPropsToCallbackProps(props.className, props),
+    convertClassPropsToCallbackProps(props),
     (callback) =>
       useStableCallback(() => {
         if (callback && elRef.current) {

--- a/packages/tiny-transition/src/react.tsx
+++ b/packages/tiny-transition/src/react.tsx
@@ -43,7 +43,7 @@ export const Transition = simpleForawrdRef(function Transition(
     () =>
       new TransitionManager({
         defaultEntered: Boolean(props.show && !props.appear),
-        ...convertClassPropsToCallbackProps(props.className, props),
+        ...convertClassPropsToCallbackProps(props),
       })
   );
   const shouldRender = React.useSyncExternalStore(
@@ -60,10 +60,7 @@ export const Transition = simpleForawrdRef(function Transition(
   }, [props.show]);
 
   React.useEffect(() => {
-    Object.assign(
-      manager.options,
-      convertClassPropsToCallbackProps(props.className, props)
-    );
+    Object.assign(manager.options, convertClassPropsToCallbackProps(props));
   }, [props]);
 
   //


### PR DESCRIPTION
- merge base https://github.com/hi-ogawa/unocss-preset-antd/pull/93

I thought this is an obvious refactoring but it turns out solidjs has some tricky ref/effect ordering, so we cannot simply do `ref={manager.ref}`.
No workaround is promising, so this PR is just for the record and I gave up.